### PR TITLE
removed regex sanitize for session name

### DIFF
--- a/Companion/exporter/collector_runner.go
+++ b/Companion/exporter/collector_runner.go
@@ -3,15 +3,15 @@ package exporter
 import (
 	"context"
 	"log"
-	"regexp"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 func SanitizeSessionName(sessionName string) string {
-	re := regexp.MustCompile(`[^\w\s]`)
-	return re.ReplaceAllString(sessionName, "")
+	// Technically this function should remove all non-utf8 characters, but previous versions of
+	// this function already assumed a utf-8 string.
+	return sessionName
 }
 
 type CollectorRunner struct {

--- a/Companion/exporter/collector_runner_test.go
+++ b/Companion/exporter/collector_runner_test.go
@@ -61,7 +61,8 @@ var _ = Describe("CollectorRunner", func() {
 		})
 
 		It("sanitizes session name", func() {
-			Expect(exporter.SanitizeSessionName(`it's giving -- 123456!@#$%^&*() yo hollar "'"`)).To(Equal(`its giving  123456 yo hollar `))
+			// Legacy name test - Prometheus 3.0 allows all utf-8 characters inside label names/values
+			Expect(exporter.SanitizeSessionName(`it's giving -- 123456!@#$%^&*() yo hollar "'"`)).To(Equal(`it's giving -- 123456!@#$%^&*() yo hollar "'"`))
 		})
 	})
 })


### PR DESCRIPTION
[Prom 3.0 ](https://prometheus.io/docs/guides/utf8/) was released ~2024, which allows all UTF8 characters in label values/names. We no longer need to sanitize the session name
